### PR TITLE
fix: add `worker` exports target

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "browser": "./dist/web/index.js",
+      "worker": "./dist/web/index.js",
       "import": "./dist/node/esm/index.js",
       "require": "./dist/node/cjs/index.js"
     },


### PR DESCRIPTION
The reason I open this PR is because this package seems to be the culprit for some breaking builds for edge runtime environments. Adding  the worker exports condition allows edge frameworks to target that instead of falling back to `import`, which relies on node APIs.

The explicit case I have is that the Vercel edge plugin for the frontend framework solid-start breaks when I import the Auth.js package `@auth/solid-start`. I tracked down the breakage to this exports condition, and found out that the vercel adapter looks for `worker` exports condition here https://github.com/solidjs/solid-start/blob/main/packages/start-vercel/index.js#L172

Here is the relevant issue on the Auth.js repo https://github.com/nextauthjs/next-auth/issues/6736